### PR TITLE
Optimise the switch process

### DIFF
--- a/check_consensus.sh
+++ b/check_consensus.sh
@@ -20,8 +20,9 @@ while true; do
 		fi
 		if [[ "$diff" -lt "3" ]]
 		then
-			curl --connect-timeout 3 -k -H "Content-Type: application/json" -X POST -d '{"secret":'"$SECRET"'}' https://"$SRV1""$PRTS"/api/delegates/forging/disable
-			curl --connect-timeout 3 -k -H "Content-Type: application/json" -X POST -d '{"secret":'"$SECRET"'}' https://"$SRV2""$PRTS"/api/delegates/forging/enable
+			curl -s --connect-timeout 3 -k -H "Content-Type: application/json" -X POST -d '{"secret":'"$SECRET"'}' https://"$SRV2""$PRTS"/api/delegates/forging/enable
+			curl -s --connect-timeout 3 -k -H "Content-Type: application/json" -X POST -d '{"secret":'"$SECRET"'}' https://"$SRV1""$PRTS"/api/delegates/forging/disable
+			
 			echo
 			echo "Switching to Server 2 to try and forge"
 			sleep 2


### PR DESCRIPTION
Because the local node is not able to reach a consensus is better to enable first and then disable in the local node. You gain some seconds that could give you a better chance to forge. And add the -s switch to suppress the `curl` statistics